### PR TITLE
Add command-line configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
 # URL Shortener
+
+## Overview
+
+The URL Shortener is a simple and efficient application that allows users to shorten long URLs, making them easier to share and manage. It provides both a client interface for URL shortening and a server component that handles requests, generates short URLs, and stores mappings between short and original URLs.
+
+## Features
+
+- Shorten long URLs and generate unique short links.
+- Retrieve original URLs from short links.
+- Handle invalid URL submissions and provide appropriate error messages.
+- Lightweight and easy to deploy.
+
+## Directory Structure
+
+- **cmd/shortener**: Contains the main server code for handling URL shortening requests. This directory will be compiled into the binary application.
+- **cmd/client**: Contains the client code for interacting with the server and shortening URLs. This directory will also be compiled into a binary application.
+- **config**: Contains configuration files and settings for the application, allowing for easy customization of server parameters and behavior.
+
+## Getting Started
+
+### Prerequisites
+
+- Go (version 1.18 or higher)
+- A working database (if using persistent storage)
+
+### Installation
+
+1. Clone the repository:
+   ```bash
+   git clone <repository-url>
+   cd <repository-name>
+2. Install the required dependencies:
+go mod tidy
+
+3. Configure your settings in the config directory as needed.
+
+4. Run the server:
+go run cmd/shortener/main.go
+
+5. Use the client to shorten URLs by running:
+go run cmd/client/main.go
+
+### Usage
+
+To shorten a URL, use the client application to send a request with the original URL. The server will respond with the shortened link.
+
+### Testing
+
+To run tests, use the following command:
+go test ./...
+
+### License
+
+This project is licensed under the MIT License - see the LICENSE file for details.
+
+### Contributing
+
+Contributions are welcome! Please open an issue or submit a pull request to contribute to the project.
+
+### Contact
+
+For inquiries, please reach out to [hairutdinl@protonmail.com].

--- a/cmd/client/README.md
+++ b/cmd/client/README.md
@@ -1,0 +1,3 @@
+# cmd/client
+
+This directory will contain the client code that is responsible for communicating with the URL shortener server. The client will send requests to the server to shorten URLs and retrieve information about shortened links. 

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,14 +1,18 @@
 package main
 
 import (
-	"github.com/gin-gonic/gin"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hairutdin/url-shortener/config"
 )
 
 func main() {
+	cfg := config.LoadConfig()
+
 	r := gin.Default()
 	r.POST("/shorten", shortenURL)
-	if err := r.Run(":8080"); err != nil {
+	if err := r.Run(cfg.ServerAddress); err != nil {
 		panic(err)
 	}
 }
@@ -20,7 +24,9 @@ func shortenURL(c *gin.Context) {
 		return
 	}
 
-	shortenedURL := "http://localhost:8080/short123"
+	cfg := config.LoadConfig()
+	shortenedURL := cfg.BaseURL + "short123"
+
 	c.JSON(http.StatusCreated, gin.H{
 		"long_url":  longURL,
 		"short_url": shortenedURL,

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -18,8 +18,10 @@ func main() {
 }
 
 func shortenURL(c *gin.Context) {
-	longURL := c.PostForm("url")
-	if longURL == "" {
+	var requestBody struct {
+		URL string `json:"url"`
+	}
+	if err := c.ShouldBindJSON(&requestBody); err != nil || requestBody.URL == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Empty URL"})
 		return
 	}
@@ -28,7 +30,7 @@ func shortenURL(c *gin.Context) {
 	shortenedURL := cfg.BaseURL + "short123"
 
 	c.JSON(http.StatusCreated, gin.H{
-		"long_url":  longURL,
+		"long_url":  requestBody.URL,
 		"short_url": shortenedURL,
 	})
 }

--- a/cmd/client/main_test.go
+++ b/cmd/client/main_test.go
@@ -6,14 +6,27 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hairutdin/url-shortener/config"
+
 	"github.com/gin-gonic/gin"
 )
 
+var mockConfig = &config.Config{
+	ServerAddress: "localhost:8080",
+	BaseURL:       "http://localhost:8080/",
+}
+
+func createTestRequest(method, url, body string) (*http.Request, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(method, url, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+	return req, recorder
+}
+
 func TestClientPost(t *testing.T) {
-	// Mock server for testing
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte("http://localhost:8080/short123"))
+		w.Write([]byte(mockConfig.BaseURL + "short123"))
 	}))
 	defer mockServer.Close()
 
@@ -21,25 +34,16 @@ func TestClientPost(t *testing.T) {
 	router := gin.Default()
 	router.POST("/shorten", shortenURL)
 
-	// Read the body
-	body := strings.NewReader("url=https://example.com")
-	req, err := http.NewRequest(http.MethodPost, "/shorten", body)
-	if err != nil {
-		t.Fatalf("Could not create request: %v", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	recorder := httptest.NewRecorder()
+	body := "url=https://example.com"
+	req, recorder := createTestRequest(http.MethodPost, "/shorten", body)
 
-	// Serve the request
 	router.ServeHTTP(recorder, req)
 
-	// Check if the response status is correct
 	if recorder.Code != http.StatusCreated {
 		t.Errorf("Expected status code %d, got %d", http.StatusCreated, recorder.Code)
 	}
 
-	// Check the response body
-	expectedBody := `{"long_url":"https://example.com","short_url":"http://localhost:8080/short123"}`
+	expectedBody := `{"long_url":"https://example.com","short_url":"` + mockConfig.BaseURL + `short123"}`
 	if recorder.Body.String() != expectedBody {
 		t.Errorf("Expected body %s, got %s", expectedBody, recorder.Body.String())
 	}

--- a/cmd/shortener/README.md
+++ b/cmd/shortener/README.md
@@ -1,3 +1,3 @@
 # cmd/shortener
 
-В данной директории будет содержаться код, который скомпилируется в бинарное приложение
+This directory will contain the code that will be compiled into a binary application

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/gin-gonic/gin"
+	"github.com/hairutdin/url-shortener/config"
 )
 
 var urlStore = struct {
@@ -15,8 +16,6 @@ var urlStore = struct {
 }{
 	m: make(map[string]string),
 }
-
-const baseURL = "http://localhost:8080/"
 
 func generateShortURL() string {
 	b := make([]byte, 6)
@@ -28,6 +27,8 @@ func generateShortURL() string {
 }
 
 func handlePost(c *gin.Context) {
+	cfg := config.LoadConfig()
+
 	var requestBody struct {
 		URL string `json:"url"`
 	}
@@ -43,7 +44,7 @@ func handlePost(c *gin.Context) {
 	urlStore.m[shortURL] = requestBody.URL
 	urlStore.Unlock()
 
-	c.JSON(http.StatusCreated, gin.H{"short_url": baseURL + shortURL})
+	c.JSON(http.StatusCreated, gin.H{"short_url": cfg.BaseURL + shortURL})
 }
 
 func handleGet(c *gin.Context) {
@@ -62,12 +63,14 @@ func handleGet(c *gin.Context) {
 }
 
 func main() {
+	cfg := config.LoadConfig()
+
 	r := gin.Default()
 
 	r.POST("/shorten", handlePost)
 	r.GET("/:id", handleGet)
 
-	if err := r.Run(":8080"); err != nil {
+	if err := r.Run(cfg.ServerAddress); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -60,7 +60,7 @@ func handleGet(c *gin.Context) {
 	originalURL, exists := urlStore.m[shortURL]
 
 	if !exists {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "URL not found"})
+		c.JSON(http.StatusNotFound, gin.H{"error": "URL not found"})
 		return
 	}
 
@@ -72,7 +72,7 @@ func main() {
 
 	r := gin.Default()
 
-	r.POST("/", handlePost)
+	r.POST("/shorten", handlePost) // Update to /shorten
 	r.GET("/:id", handleGet)
 
 	if err := r.Run(cfg.ServerAddress); err != nil {

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,3 @@
+# config
+
+This directory will contain the application configuration, including server parameters and settings required for the URL redirector to work correctly. The configuration can be loaded from files or set via environment variables.

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"flag"
+)
+
+type Config struct {
+	ServerAddress string
+	BaseURL       string
+}
+
+var (
+	serverAddressFlag = "localhost:8080"
+	baseURLFlag       = "http://localhost:8080/"
+)
+
+var flagParsed = false
+
+func LoadConfig() *Config {
+	if !flagParsed {
+		serverAddress := flag.String("a", serverAddressFlag, "HTTP server address")
+		baseURL := flag.String("b", baseURLFlag, "Base URL for short URLs")
+		flag.Parse()
+		flagParsed = true
+
+		return &Config{
+			ServerAddress: *serverAddress,
+			BaseURL:       *baseURL,
+		}
+	}
+
+	return &Config{
+		ServerAddress: serverAddressFlag,
+		BaseURL:       baseURLFlag,
+	}
+}


### PR DESCRIPTION
Implemented command-line flags for configuring the URL shortener service. 

- Added flag -a for specifying the HTTP server address (e.g., localhost:8888).

- Added flag -b for setting the base URL for the shortened links (e.g., http://localhost:8000/shortID).

- Created a separate config package to manage the configuration structure and initialization.

This update enhances the flexibility of the service and allows for easier deployment in various environments.