### PR TITLE
Add Gzip Support for Requests and Responses

### DIFF
--- a/cmd/client/main_test.go
+++ b/cmd/client/main_test.go
@@ -58,3 +58,22 @@ func TestClientPost(t *testing.T) {
 		t.Errorf("Expected body %s, got %s", expectedBody, recorder.Body.String())
 	}
 }
+
+func TestClientPostInvalidURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	router.POST("/", testShortenURL)
+
+	body := `{"url": ""}`
+	req, recorder := createTestRequest(http.MethodPost, "/", body)
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Errorf("Expected status code %d, got %d", http.StatusBadRequest, recorder.Code)
+	}
+
+	expectedBody := `{"error":"Invalid URL"}`
+	if recorder.Body.String() != expectedBody {
+		t.Errorf("Expected body %s, got %s", expectedBody, recorder.Body.String())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,11 @@ module github.com/hairutdin/url-shortener
 
 go 1.22.5
 
-require github.com/gin-gonic/gin v1.10.0
+require (
+	github.com/gin-gonic/gin v1.10.0
+	github.com/mailru/easyjson v0.7.7
+	go.uber.org/zap v1.27.0
+)
 
 require (
 	github.com/bytedance/sonic v1.12.3 // indirect
@@ -19,7 +23,6 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.8 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
@@ -27,7 +30,6 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/arch v0.10.0 // indirect
 	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/net v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=


### PR DESCRIPTION
- Implemented gzip compression for server responses if the client supports it, using the Accept-Encoding: gzip header.
- Added handling for gzip-encoded request bodies in the server when the Content-Encoding: gzip header is present.
- Created middleware (GzipMiddleware) to handle compression for specific content types: application/json and text/html.
- Updated client functionality to optionally send gzip-encoded data in requests.
- Ensured compatibility of the gzip compression with various API endpoints, including /api/shorten and root (/) paths.