### PR TITLE
Add file-based storage for shortened URLs

### DIFF
--- a/cmd/shortener/main_test.go
+++ b/cmd/shortener/main_test.go
@@ -1,8 +1,12 @@
 package shortener
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -11,8 +15,9 @@ import (
 )
 
 var mockConfig = &config.Config{
-	ServerAddress: "localhost:8080",
-	BaseURL:       "http://localhost:8080/",
+	ServerAddress:   "localhost:8080",
+	BaseURL:         "http://localhost:8080/",
+	FileStoragePath: "/tmp/test-short-url-db.json",
 }
 
 func createTestContext() (*gin.Context, *httptest.ResponseRecorder) {
@@ -22,6 +27,8 @@ func createTestContext() (*gin.Context, *httptest.ResponseRecorder) {
 }
 
 func TestHandleShortenPost(t *testing.T) {
+	defer os.Remove(mockConfig.FileStoragePath)
+
 	gin.SetMode(gin.TestMode)
 	c, res := createTestContext()
 
@@ -60,13 +67,66 @@ func TestHandleShortenPostInvalidBody(t *testing.T) {
 	}
 }
 
+func createGzipRequestBody(body string) *bytes.Buffer {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	gz.Write([]byte(body))
+	gz.Close()
+	return &buf
+}
+
+func TestHandleShortenPostWithGzip(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, res := createTestContext()
+
+	gzipBody := createGzipRequestBody(`{"url": "https://example.com"}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/shorten", gzipBody)
+	c.Request.Header.Set("Content-Encoding", "gzip")
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handleShortenPost(c)
+
+	if res.Code != http.StatusCreated {
+		t.Errorf("Expected status 201, got %d", res.Code)
+	}
+
+	if !strings.Contains(res.Body.String(), mockConfig.BaseURL) {
+		t.Errorf("Expected base URL in response, got %s", res.Body.String())
+	}
+}
+
+func TestHandleShortenPostWithInvalidGzip(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, res := createTestContext()
+
+	invalidGzipBody := strings.NewReader("invalid gzip data")
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/shorten", invalidGzipBody)
+	c.Request.Header.Set("Content-Encoding", "gzip")
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handleShortenPost(c)
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for invalid gzip, got %d", res.Code)
+	}
+
+	expectedError := `{"error":"Failed to read gzip body"}`
+	if strings.TrimSpace(res.Body.String()) != expectedError {
+		t.Errorf("Expected '%s', got %s", expectedError, res.Body.String())
+	}
+}
+
 func TestHandleGet(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	shortID := "short12345"
 	originalURL := "https://example.com"
 	urlStore.Lock()
-	urlStore.m[shortID] = originalURL
+	urlStore.m[shortID] = ShortenedURL{
+		UUID:        "1",
+		ShortURL:    shortID,
+		OriginalURL: originalURL,
+	}
 	urlStore.Unlock()
 
 	c, res := createTestContext()
@@ -106,5 +166,98 @@ func TestHandleGetInvalidID(t *testing.T) {
 	expectedError := `{"error":"URL not found"}`
 	if strings.TrimSpace(res.Body.String()) != expectedError {
 		t.Errorf("Expected 'Expected '%s', got %s", expectedError, res.Body.String())
+	}
+}
+
+func TestSaveURLsToFile(t *testing.T) {
+	defer os.Remove(mockConfig.FileStoragePath)
+
+	urlStore.m["short123"] = ShortenedURL{
+		UUID:        "1",
+		ShortURL:    "short123",
+		OriginalURL: "https://example.com",
+	}
+
+	err := saveURLsToFile(mockConfig.FileStoragePath)
+	if err != nil {
+		t.Fatalf("Failed to save URLs to file: %v", err)
+	}
+
+	_, err = os.Stat(mockConfig.FileStoragePath)
+	if os.IsNotExist(err) {
+		t.Fatalf("File was not created: %v", err)
+	}
+}
+
+func resetURLStore() {
+	urlStore.Lock()
+	defer urlStore.Unlock()
+	urlStore.m = make(map[string]ShortenedURL)
+}
+
+func TestLoadURLsFromFile(t *testing.T) {
+	resetURLStore()
+
+	tmpFile, err := os.CreateTemp("", "test_url_store_*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	urls := []ShortenedURL{
+		{UUID: "1", ShortURL: "short123", OriginalURL: "https://example.com"},
+		{UUID: "2", ShortURL: "short456", OriginalURL: "https://another.com"},
+	}
+	fileData, _ := json.Marshal(urls)
+	tmpFile.Write(fileData)
+	tmpFile.Close()
+
+	cfg := &config.Config{
+		FileStoragePath: tmpFile.Name(),
+	}
+
+	err = loadURLsFromFile(cfg.FileStoragePath)
+	if err != nil {
+		t.Fatalf("Failed to load URLs from file: %v", err)
+	}
+
+	urlStore.RLock()
+	defer urlStore.RUnlock()
+	if len(urlStore.m) != 2 {
+		t.Errorf("Expected 2 URLs to be loaded, but got %d", len(urlStore.m))
+	}
+
+	if urlStore.m["short123"].OriginalURL != "https://example.com" {
+		t.Errorf("Expected URL 'https://example.com', got '%s'", urlStore.m["short123"].OriginalURL)
+	}
+}
+
+func TestMain(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test_url_store_main_*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	urlData := []ShortenedURL{
+		{UUID: "1", ShortURL: "short123", OriginalURL: "https://example.com"},
+	}
+	fileData, _ := json.Marshal(urlData)
+	tmpFile.Write(fileData)
+	tmpFile.Close()
+
+	cfg := &config.Config{
+		FileStoragePath: tmpFile.Name(),
+	}
+
+	err = loadURLsFromFile(cfg.FileStoragePath)
+	if err != nil {
+		t.Fatalf("Failed to load URLs from file: %v", err)
+	}
+
+	urlStore.RLock()
+	defer urlStore.RUnlock()
+	if _, exists := urlStore.m["short123"]; !exists {
+		t.Errorf("Expected URL 'short123' to be loaded")
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,13 +6,15 @@ import (
 )
 
 type Config struct {
-	ServerAddress string
-	BaseURL       string
+	ServerAddress   string
+	BaseURL         string
+	FileStoragePath string
 }
 
 var (
 	defaultServerAddress = "localhost:8080"
 	defaultBaseURL       = "http://localhost:8080/"
+	defaultFileStorage   = "/tmp/short-url-db.json"
 )
 
 var flagParsed = false
@@ -21,9 +23,12 @@ func LoadConfig() *Config {
 	if !flagParsed {
 		serverAddress := os.Getenv("SERVER_ADDRESS")
 		baseURL := os.Getenv("BASE_URL")
+		fileStoragePath := os.Getenv("FILE_STORAGE_PATH")
 
 		serverAddressFlag := flag.String("a", defaultServerAddress, "HTTP server address")
 		baseURLFlag := flag.String("b", defaultBaseURL, "Base URL for short URLs")
+		fileStorageFlag := flag.String("f", defaultFileStorage, "File storage path for URL data")
+
 		flag.Parse()
 		flagParsed = true
 
@@ -35,14 +40,20 @@ func LoadConfig() *Config {
 			baseURL = *baseURLFlag
 		}
 
+		if fileStoragePath == "" {
+			fileStoragePath = *fileStorageFlag
+		}
+
 		return &Config{
-			ServerAddress: serverAddress,
-			BaseURL:       baseURL,
+			ServerAddress:   serverAddress,
+			BaseURL:         baseURL,
+			FileStoragePath: fileStoragePath,
 		}
 	}
 
 	return &Config{
-		ServerAddress: defaultServerAddress,
-		BaseURL:       defaultBaseURL,
+		ServerAddress:   defaultServerAddress,
+		BaseURL:         defaultBaseURL,
+		FileStoragePath: defaultFileStorage,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.5
 
 require (
 	github.com/gin-gonic/gin v1.10.0
+	github.com/google/uuid v1.6.0
 	github.com/mailru/easyjson v0.7.7
 	go.uber.org/zap v1.27.0
 )

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PU
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=


### PR DESCRIPTION
- Implemented saving shortened URLs to a file in JSON format.
- The file path can be configured via the -f flag or the FILE_STORAGE_PATH environment variable, defaulting to /tmp/short-url-db.json.
- On server restart, the URLs are restored from the file if available.
- Added functionality to handle gzip-encoded requests and responses for URL shortening.