### PR TITLE
Add Batch URL Shortening Handler

### DIFF
--- a/cmd/shortener/models.go
+++ b/cmd/shortener/models.go
@@ -6,6 +6,18 @@ type ShortenRequest struct {
 }
 
 // easyjson:json
+type BatchShortenRequest struct {
+	CorrelationID string `json:"correlation_id"`
+	OriginalURL   string `json:"original_url"`
+}
+
+// easyjson:json
 type ShortenResponse struct {
 	Result string `json:"result"`
+}
+
+// easyjson:json
+type BatchShortenResponse struct {
+	CorrelationID string `json:"correlation_id"`
+	ShortURL      string `json:"short_url"`
 }

--- a/cmd/shortener/models_easyjson.go
+++ b/cmd/shortener/models_easyjson.go
@@ -149,3 +149,149 @@ func (v *ShortenRequest) UnmarshalJSON(data []byte) error {
 func (v *ShortenRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonD2b7633eDecodeGithubComHairutdinUrlShortenerCmdShortener1(l, v)
 }
+func easyjsonD2b7633eDecodeGithubComHairutdinUrlShortenerCmdShortener2(in *jlexer.Lexer, out *BatchShortenResponse) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "correlation_id":
+			out.CorrelationID = string(in.String())
+		case "short_url":
+			out.ShortURL = string(in.String())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonD2b7633eEncodeGithubComHairutdinUrlShortenerCmdShortener2(out *jwriter.Writer, in BatchShortenResponse) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"correlation_id\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.CorrelationID))
+	}
+	{
+		const prefix string = ",\"short_url\":"
+		out.RawString(prefix)
+		out.String(string(in.ShortURL))
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v BatchShortenResponse) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjsonD2b7633eEncodeGithubComHairutdinUrlShortenerCmdShortener2(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v BatchShortenResponse) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonD2b7633eEncodeGithubComHairutdinUrlShortenerCmdShortener2(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *BatchShortenResponse) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjsonD2b7633eDecodeGithubComHairutdinUrlShortenerCmdShortener2(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *BatchShortenResponse) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonD2b7633eDecodeGithubComHairutdinUrlShortenerCmdShortener2(l, v)
+}
+func easyjsonD2b7633eDecodeGithubComHairutdinUrlShortenerCmdShortener3(in *jlexer.Lexer, out *BatchShortenRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "correlation_id":
+			out.CorrelationID = string(in.String())
+		case "original_url":
+			out.OriginalURL = string(in.String())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonD2b7633eEncodeGithubComHairutdinUrlShortenerCmdShortener3(out *jwriter.Writer, in BatchShortenRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"correlation_id\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.CorrelationID))
+	}
+	{
+		const prefix string = ",\"original_url\":"
+		out.RawString(prefix)
+		out.String(string(in.OriginalURL))
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v BatchShortenRequest) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjsonD2b7633eEncodeGithubComHairutdinUrlShortenerCmdShortener3(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v BatchShortenRequest) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonD2b7633eEncodeGithubComHairutdinUrlShortenerCmdShortener3(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *BatchShortenRequest) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjsonD2b7633eDecodeGithubComHairutdinUrlShortenerCmdShortener3(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *BatchShortenRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonD2b7633eDecodeGithubComHairutdinUrlShortenerCmdShortener3(l, v)
+}

--- a/internal/storage/file_storage_test.go
+++ b/internal/storage/file_storage_test.go
@@ -43,6 +43,35 @@ func TestCreateShortURL(t *testing.T) {
 	assert.Equal(t, testOriginalURL, originalURL, "Original URL should match expected value")
 }
 
+func TestFileStorageBatchURLs(t *testing.T) {
+	fs, cleanup := setupFileStorage()
+	defer cleanup()
+
+	batchRequests := []BatchURLRequest{
+		{
+			UUID:        uuid.New().String(),
+			ShortURL:    "short1",
+			OriginalURL: "https://example.com/1",
+		},
+		{
+			UUID:        uuid.New().String(),
+			ShortURL:    "short2",
+			OriginalURL: "https://example.com/2",
+		},
+	}
+
+	for _, req := range batchRequests {
+		err := fs.CreateShortURL(req.UUID, req.ShortURL, req.OriginalURL)
+		assert.NoError(t, err, "CreateShortURL should not return an error")
+	}
+
+	for _, req := range batchRequests {
+		originalURL, err := fs.GetOriginalURL(req.ShortURL)
+		assert.NoError(t, err, "GetOriginalURL should not return an error")
+		assert.Equal(t, req.OriginalURL, originalURL, "The original URL should match the expected value")
+	}
+}
+
 func TestGetOriginalURLNotFound(t *testing.T) {
 	fs, cleanup := setupFileStorage()
 	defer cleanup()

--- a/internal/storage/memory_storage.go
+++ b/internal/storage/memory_storage.go
@@ -22,6 +22,26 @@ func (m *InMemoryStorage) CreateShortURL(uuid, shortURL, originalURL string) err
 	return nil
 }
 
+func (m *InMemoryStorage) CreateBatchURLs(urls []BatchURLRequest) ([]BatchURLOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var output []BatchURLOutput
+
+	for _, url := range urls {
+		if _, exists := m.urls[url.ShortURL]; exists {
+			return nil, errors.New("duplicate short URL")
+		}
+		m.urls[url.ShortURL] = url.OriginalURL
+		output = append(output, BatchURLOutput{
+			CorrelationID: url.UUID,
+			ShortURL:      "http://localhost:8080/" + url.ShortURL,
+		})
+	}
+
+	return output, nil
+}
+
 func (m *InMemoryStorage) GetOriginalURL(shortURL string) (string, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/internal/storage/memory_storage_test.go
+++ b/internal/storage/memory_storage_test.go
@@ -26,6 +26,27 @@ func TestInMemoryStorageCreateAndGetURL(t *testing.T) {
 	assert.Equal(t, testOriginalURL, originalURL, "Original URL should match the expected value")
 }
 
+func TestInMemoryStorageBatchCreate(t *testing.T) {
+	memoryStorage := setupInMemoryStorage()
+
+	batchURLs := []BatchURLRequest{
+		{UUID: uuid.New().String(), ShortURL: "short1", OriginalURL: "https://example.com/1"},
+		{UUID: uuid.New().String(), ShortURL: "short2", OriginalURL: "https://example.com/2"},
+	}
+
+	// Test batch creation of short URLs
+	batchOutputs, err := memoryStorage.CreateBatchURLs(batchURLs)
+	assert.NoError(t, err, "CreateBatchURLs should not return an error")
+	assert.Len(t, batchOutputs, len(batchURLs), "The output length should match the input length")
+
+	// Verify each URL was created correctly
+	for i := range batchOutputs {
+		originalURL, err := memoryStorage.GetOriginalURL(batchURLs[i].ShortURL)
+		assert.NoError(t, err, "GetOriginalURL should not return an error")
+		assert.Equal(t, batchURLs[i].OriginalURL, originalURL, "The retrieved URL should match the original URL")
+	}
+}
+
 func TestInMemoryStorageGetOriginalURLNotFound(t *testing.T) {
 	memoryStorage := setupInMemoryStorage()
 

--- a/internal/storage/postgres_storage_test.go
+++ b/internal/storage/postgres_storage_test.go
@@ -42,6 +42,24 @@ func TestPostgresStorageCreateAndGetURL(t *testing.T) {
 	assert.Equal(t, testOriginalURL, originalURL, "Original URL should match the expected value")
 }
 
+func TestPostgresStorageCreateBatchURLs(t *testing.T) {
+	storage := setupTestDB(t)
+	defer storage.Close()
+
+	batchRequests := []BatchURLRequest{
+		{UUID: uuid.New().String(), ShortURL: "short1", OriginalURL: "https://example.com/1"},
+		{UUID: uuid.New().String(), ShortURL: "short2", OriginalURL: "https://example.com/2"},
+	}
+
+	results, err := storage.CreateBatchURLs(batchRequests)
+	assert.NoError(t, err, "CreateBatchURLs should not return an error")
+	assert.Len(t, results, 2, "There should be two results returned")
+
+	for _, result := range results {
+		assert.NotEmpty(t, result.ShortURL, "Short URL should not be empty")
+	}
+}
+
 func TestPostgresStorageGetOriginalURLNotFound(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -3,6 +3,7 @@ package storage
 type Storage interface {
 	CreateShortURL(uuid, shortURL, originalURL string) error
 	GetOriginalURL(shortURL string) (string, error)
+	CreateBatchURLs(urls []BatchURLRequest) ([]BatchURLOutput, error)
 	Ping() error
 	Close() error
 }

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -1,0 +1,12 @@
+package storage
+
+type BatchURLRequest struct {
+	UUID        string
+	ShortURL    string
+	OriginalURL string
+}
+
+type BatchURLOutput struct {
+	CorrelationID string
+	ShortURL      string
+}


### PR DESCRIPTION
- Implemented a new handler POST /api/shorten/batch for batch processing of URL shortening requests.
- Enhanced PostgresStorage, FileStorage, and InMemoryStorage to support batch URL creation.
- Updated tests to verify batch functionality across different storage implementations.